### PR TITLE
统一 NPC 中英文姓名

### DIFF
--- a/guide/npc.html
+++ b/guide/npc.html
@@ -180,6 +180,11 @@
             stroke: #05070f;
             stroke-width: 3px;
         }
+        .rel-svg .node text.label .label-en {
+            fill: #94a3b8;
+            font-size: 10px;
+            font-weight: 400;
+        }
         .rel-svg .node text.initials {
             fill: #fff;
             font-weight: 800;
@@ -316,7 +321,7 @@
                         <img src="/assets/img/npc/tyrell.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">主席 Tyrell<span class="en">Colin Tyrell · Principal / Governor</span></div>
+                        <div class="npc-name">主席 柯林·泰瑞尔（Colin Tyrell）<span class="en">Principal / Governor</span></div>
                         <div class="npc-meta"><span class="chip">人类男</span><span class="chip acc">最高首长</span></div>
                         <div class="npc-desc">Pioneer 2 的行政与军事最高负责人，正直、严厉、深受殖民者爱戴。丧偶，为唯一的女儿 <strong>Red Ring Rico</strong> 日夜忧心。与 <strong>Flowen</strong> 是多年挚友。</div>
                     </div>
@@ -328,7 +333,7 @@
                         <img src="/assets/img/npc/irene.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Irene<span class="en">Tyrell&apos;s Secretary</span></div>
+                        <div class="npc-name">艾琳（Irene）<span class="en">Tyrell&apos;s Secretary</span></div>
                         <div class="npc-meta"><span class="chip">人类女</span><span class="chip">秘书</span></div>
                         <div class="npc-desc">主席府秘书，Ep1 前期由她替 Tyrell 发布任务、向 Hunter 透露「主席的女儿在 Pioneer 1 上」这一情报。</div>
                     </div>
@@ -340,7 +345,7 @@
                         <img src="/assets/img/npc/natasha.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Natasha Milarose<span class="en">Lab General Chief</span></div>
+                        <div class="npc-name">娜塔莎·米拉萝丝（Natasha Milarose）<span class="en">Lab General Chief</span></div>
                         <div class="npc-meta"><span class="chip">人类女</span><span class="chip acc">Lab 首席</span></div>
                         <div class="npc-desc">Pioneer 2 中央研究所总负责人。Ep2 主线任务的派发者；Ep4 中对 <strong>Paganini</strong> 的研究方向持批评态度。</div>
                     </div>
@@ -352,7 +357,7 @@
                         <img src="/assets/img/npc/paganini.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Paganini<span class="en">Crater Research Lead</span></div>
+                        <div class="npc-name">帕加尼尼（Paganini）<span class="en">Crater Research Lead</span></div>
                         <div class="npc-meta"><span class="chip">人类</span><span class="chip alt">Ep4 研究员</span></div>
                         <div class="npc-desc">Ep4 在陨石坑展开研究的首席科学家。对玩家身份守口如瓶，研究项目引起上级 Natasha 的强烈不满。</div>
                     </div>
@@ -375,7 +380,7 @@
                         <img src="/assets/img/npc/rico.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Red Ring Rico（Rico Tyrell）<span class="en">HUnewearl · Pioneer 1 Hero</span></div>
+                        <div class="npc-name">红环莉可（Red Ring Rico；本名 Rico Tyrell）<span class="en">HUnewearl · Pioneer 1 Hero</span></div>
                         <div class="npc-meta"><span class="chip">HUnewearl</span><span class="chip acc">主席之女</span><span class="chip warn">Ep1 BOSS 宿主</span></div>
                         <div class="npc-desc">传奇猎人兼科学家，因左手标志性的红色臂环得名「红环 Rico」。<strong>Tyrell</strong> 的女儿、<strong>Flowen</strong> 的徒弟——她的 <em>Red Ring / Red</em> 系列装备均为师父所赠。Ragol 大爆炸后留下多段全息记录，最终被 <strong>Dark Falz</strong> 附身成为 Ep1 的最终 BOSS；玩家击败 DF 后她的灵魂才得以解脱。</div>
                     </div>
@@ -387,7 +392,7 @@
                         <img src="/assets/img/npc/flowen.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Heathcliff Flowen<span class="en">Pioneer 1 Deputy Commander</span></div>
+                        <div class="npc-name">希斯克利夫·弗洛文（Heathcliff Flowen）<span class="en">Pioneer 1 Deputy Commander</span></div>
                         <div class="npc-meta"><span class="chip">人类男</span><span class="chip acc">副司令</span><span class="chip warn">Ep2 BOSS 本体</span></div>
                         <div class="npc-desc">Pioneer 1 军队副司令，剑圣，Rico 的师父，与 <strong>Tyrell</strong> 是老友。身上的 <em>Flowen&apos;s Sword</em> 是他的代表武器。在与 Rico 并肩作战时感染 Flow 寄生基因；Ep2 中他的躯体被研究者强行与 <strong>D-Photon Core</strong> 融合，异变为 Episode 2 的最终 BOSS <strong>Olga Flow</strong>。</div>
                     </div>
@@ -399,7 +404,7 @@
                         <img src="/assets/img/npc/endu.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Endu<span class="en">Fusion of Rico &amp; Flowen</span></div>
+                        <div class="npc-name">恩杜（Endu）<span class="en">Fusion of Rico &amp; Flowen</span></div>
                         <div class="npc-meta"><span class="chip alt">Ep3 桥梁</span></div>
                         <div class="npc-desc">Rico 与 Flowen 的意识在迫使 Dark Falz 与 Olga Flow 共鸣时「融合」所生的新生命，象征两大寄生体的被封印，并为 Episode 3 的剧情衔接奠基。</div>
                     </div>
@@ -421,7 +426,7 @@
                         <span>OH</span>
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Dr. Osto Hyle<span class="en">Pioneer 1 Lab Chief</span></div>
+                        <div class="npc-name">奥斯托·海尔博士（Dr. Osto Hyle）<span class="en">Pioneer 1 Lab Chief</span></div>
                         <div class="npc-meta"><span class="chip">人类男</span><span class="chip acc">Pioneer 1 首席</span></div>
                         <div class="npc-desc">遗传工程与电学权威，Pioneer 1 研究团队首席。与 <strong>Montague</strong> 共同开发 <em>Mag</em> 并发起「<strong>MOTHER 计划</strong>」。痴迷 Ragol 的未知生命（D 因子），在出发前秘密向 Coral 母星回报，前往 Ragol 后下落不明。</div>
                     </div>
@@ -433,7 +438,7 @@
                         <img src="/assets/img/npc/montague.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Dr. Jean Carlo Montague<span class="en">FOnewm · Eccentric Scientist</span></div>
+                        <div class="npc-name">吉恩·卡洛·蒙塔古博士（Dr. Jean Carlo Montague）<span class="en">FOnewm · Eccentric Scientist</span></div>
                         <div class="npc-meta"><span class="chip">FOnewm</span><span class="chip alt">MOTHER 计划</span></div>
                         <div class="npc-desc">Pioneer 2 天才科学家，生物力学与光子工程权威。态度古怪但并非恶人。<strong>Osto</strong> 的搭档，<strong>Elenor</strong> 的创造者；Osto 随 Pioneer 1 离开后，他大幅改动了 MOTHER 计划的方向。</div>
                     </div>
@@ -445,7 +450,7 @@
                         <img src="/assets/img/npc/elenor.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Elenor Camuel<span class="en">RAcaseal · Montague&apos;s Creation</span></div>
+                        <div class="npc-name">艾尔诺亚·卡缪（Elenor Camuel）<span class="en">RAcaseal · Montague&apos;s Creation</span></div>
                         <div class="npc-meta"><span class="chip">RAcaseal</span><span class="chip alt">Mag 语通译</span></div>
                         <div class="npc-desc">由 Montague 一手打造的女性机器人，天赋异禀能理解 Mag 的「话语」。忠于创造者，但内心渴望脱离实验室，拥有真正的朋友与普通人生。</div>
                     </div>
@@ -457,7 +462,7 @@
                         <img src="/assets/img/npc/calus.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Calus<span class="en">Central Control Tower AI</span></div>
+                        <div class="npc-name">卡鲁斯（Calus）<span class="en">Central Control Tower AI</span></div>
                         <div class="npc-meta"><span class="chip alt">AI</span><span class="chip warn">失控</span></div>
                         <div class="npc-desc">寄居在中央控制塔的人工智能。玩家与 Elly 协助其构筑实体时发生异常，Calus 开始向未知生命体方向进化；任务中 <strong>Kireek</strong> 反常地加入玩家一侧以求终止其失控。</div>
                     </div>
@@ -469,7 +474,7 @@
                         <img src="/assets/img/npc/alicia.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Alicia Baz<span class="en">FOmarl · Lab Assistant</span></div>
+                        <div class="npc-name">艾莉西亚·巴兹（Alicia Baz）<span class="en">FOmarl · Lab Assistant</span></div>
                         <div class="npc-meta"><span class="chip">FOmarl</span></div>
                         <div class="npc-desc">实验室研究助理。对政府分配的室内研究感到厌倦，辞职后立志亲身走进 Ragol 研究本土生物。</div>
                     </div>
@@ -493,7 +498,7 @@
                         <img src="/assets/img/npc/kireek.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Kireek<span class="en">HUcast · &quot;Black Hound&quot;</span></div>
+                        <div class="npc-name">基里克（Kireek）<span class="en">HUcast · &quot;Black Hound&quot;</span></div>
                         <div class="npc-meta"><span class="chip">HUcast</span><span class="chip warn">处刑人</span></div>
                         <div class="npc-desc">Black Paper 高层执行者，人称「黑犬」。冷酷、纯逻辑派，爱剑 <em>Soul Eater</em>。在 Calus 事件中罕见地与玩家并肩作战。</div>
                     </div>
@@ -505,7 +510,7 @@
                         <img src="/assets/img/npc/sue.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Sue<span class="en">HUnewearl · Mole inside Black Paper</span></div>
+                        <div class="npc-name">苏（Sue）<span class="en">HUnewearl · Mole inside Black Paper</span></div>
                         <div class="npc-meta"><span class="chip">HUnewearl</span><span class="chip alt">潜伏调查</span></div>
                         <div class="npc-desc">常与 Kireek 搭档，但她加入 Black Paper 的真正动机是挖掘 <strong>MOTHER 计划</strong>的真相。感性、重义气，是 Kireek 冷硬逻辑的反面映照。</div>
                     </div>
@@ -517,7 +522,7 @@
                         <img src="/assets/img/npc/tobokke.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Tobokke / Tonzlar / Gekigasky<span class="en">Black Paper Operatives</span></div>
+                        <div class="npc-name">托波克（Tobokke）/ 通兹拉（Tonzlar）/ 盖基加斯基（Gekigasky）<span class="en">Black Paper Operatives</span></div>
                         <div class="npc-meta"><span class="chip">HUmar / RAmar</span></div>
                         <div class="npc-desc">在「Black Paper」任务线中出现的其他成员，主要承担执行与对抗玩家的戏份。</div>
                     </div>
@@ -540,7 +545,7 @@
                         <img src="/assets/img/npc/nol.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Nol Rinale<span class="en">HUnewearl · Journalist</span></div>
+                        <div class="npc-name">诺尔·莉奈尔（Nol Rinale）<span class="en">HUnewearl · Journalist</span></div>
                         <div class="npc-meta"><span class="chip">HUnewearl</span><span class="chip alt">记者</span></div>
                         <div class="npc-desc">Ep1 任务《Journalistic Pursuit》中追查 Ragol 真相的女记者；Ep2 回归，在 Lab 担任 Natasha 麾下的临时研究员，替她发布 Ep2 主线任务。</div>
                     </div>
@@ -552,7 +557,7 @@
                         <img src="/assets/img/npc/momoka.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Momoka<span class="en">Ep4 Story NPC</span></div>
+                        <div class="npc-name">莫莫卡（Momoka）<span class="en">Ep4 Story NPC</span></div>
                         <div class="npc-meta"><span class="chip">女</span><span class="chip alt">Ep4 派发者</span></div>
                         <div class="npc-desc">Blue Burst 独占 Episode 4 的主线发布人。陨石坠落后，由她将陨石坑的任务交给 Hunter。</div>
                     </div>
@@ -564,7 +569,7 @@
                         <img src="/assets/img/npc/ash.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Ash<span class="en">HUmar · Rookie Hunter</span></div>
+                        <div class="npc-name">阿修（Ash）<span class="en">HUmar · Rookie Hunter</span></div>
                         <div class="npc-meta"><span class="chip">HUmar</span></div>
                         <div class="npc-desc">刚出道的菜鸟 Hunter。在「Battle Training」中被玩家搭救，之后任务也多由他那位有钱舅舅替他善后。</div>
                     </div>
@@ -576,7 +581,7 @@
                         <img src="/assets/img/npc/bernie.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Bernie<span class="en">RAmar · Pioneer 1 Investigator</span></div>
+                        <div class="npc-name">伯尼（Bernie）<span class="en">RAmar · Pioneer 1 Investigator</span></div>
                         <div class="npc-meta"><span class="chip">RAmar</span><span class="chip warn">殉职</span></div>
                         <div class="npc-desc">调查 Pioneer 1 遗迹的自由调查员，与剑客 <strong>Zoke Miyama</strong> 结伴深入 Ruins，双双被怪物吞噬。</div>
                     </div>
@@ -588,7 +593,7 @@
                         <img src="/assets/img/npc/zoke.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Zoke Miyama<span class="en">The Great Sword</span></div>
+                        <div class="npc-name">佐克·美山（Zoke Miyama）<span class="en">The Great Sword</span></div>
                         <div class="npc-meta"><span class="chip">剑客</span><span class="chip warn">重伤</span></div>
                         <div class="npc-desc">人称「大剑客」的浪人剑士，RAcaseal <strong>Shino</strong> 的主人。《Seek my Master》中被 Shino 在 Ruins 深处找到时已奄奄一息。</div>
                     </div>
@@ -600,7 +605,7 @@
                         <img src="/assets/img/npc/shino.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Shino<span class="en">RAcaseal</span></div>
+                        <div class="npc-name">紫乃（Shino）<span class="en">RAcaseal</span></div>
                         <div class="npc-meta"><span class="chip">RAcaseal</span></div>
                         <div class="npc-desc">为寻找失踪的主人 Zoke Miyama 请求 Hunter&apos;s Guild 协助的女性机器人。</div>
                     </div>
@@ -612,7 +617,7 @@
                         <img src="/assets/img/npc/rupika.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Rupika<span class="en">FOnewearl · Survivor</span></div>
+                        <div class="npc-name">鲁毕卡（Rupika）<span class="en">FOnewearl · Survivor</span></div>
                         <div class="npc-meta"><span class="chip">FOnewearl</span></div>
                         <div class="npc-desc">《Gran Squall》中被玩家救下的幸存者，是所有 FOnewearl 模板 NPC 里唯一有正式名字的角色。</div>
                     </div>
@@ -635,7 +640,7 @@
                         <img src="/assets/img/npc/darkfalz.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Dark Falz<span class="en">God of Darkness</span></div>
+                        <div class="npc-name">暗黑佛 / 黑暗法尔兹（Dark Falz）<span class="en">God of Darkness</span></div>
                         <div class="npc-meta"><span class="chip warn">Ep1 终 BOSS</span></div>
                         <div class="npc-desc">Pioneer 1 解封 Ragol 三根封印之柱时觉醒的暗之神，附身在被寄生的 Rico 身上。拥有自复活能力。</div>
                     </div>
@@ -647,7 +652,7 @@
                         <img src="/assets/img/npc/olga.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Olga Flow<span class="en">D-Photon Core Hybrid</span></div>
+                        <div class="npc-name">奥尔加·弗洛（Olga Flow）<span class="en">D-Photon Core Hybrid</span></div>
                         <div class="npc-meta"><span class="chip warn">Ep2 终 BOSS</span></div>
                         <div class="npc-desc">Flowen 被 Flow 基因感染后的躯体，与研究人员强行植入的 D-Photon Core 融合成的巨兽，被封存在海底深渊。</div>
                     </div>
@@ -659,7 +664,7 @@
                         <img src="/assets/img/npc/mother.webp" alt="" onerror="this.remove()">
                     </div>
                     <div class="npc-body">
-                        <div class="npc-name">Mother Trinity<span class="en">Coral Lunar AI</span></div>
+                        <div class="npc-name">三位一体母神（Mother Trinity）<span class="en">Coral Lunar AI</span></div>
                         <div class="npc-meta"><span class="chip alt">远景设定</span></div>
                         <div class="npc-desc">Coral 卫星 Arca 上的人工智能。在 Pioneer 计划彻底失败后被母星启动，最终判定人类为「行星之害」，向 Coral 投放热核灾难——这也是 Phantasy Star 后续作品废土世界的起点。</div>
                     </div>
@@ -788,41 +793,41 @@
 
                 <!-- ─── 节点（头像圆 + 外环 + 下方名字） ─── -->
                 <!-- GOV -->
-                <g class="node gov"><circle class="av-bg" cx="295" cy="80" r="30" fill="url(#pat-tyrell)"/><circle class="av-ring" cx="295" cy="80" r="30"/><text class="label" x="295" y="130">Tyrell</text></g>
-                <g class="node gov"><circle class="av-bg" cx="120" cy="150" r="30" fill="url(#pat-irene)"/><circle class="av-ring" cx="120" cy="150" r="30"/><text class="label" x="120" y="200">Irene</text></g>
-                <g class="node gov"><circle class="av-bg" cx="130" cy="290" r="30" fill="url(#pat-natasha)"/><circle class="av-ring" cx="130" cy="290" r="30"/><text class="label" x="130" y="340">Natasha</text></g>
-                <g class="node gov"><circle class="av-bg" cx="130" cy="410" r="30" fill="url(#pat-paganini)"/><circle class="av-ring" cx="130" cy="410" r="30"/><text class="label" x="130" y="460">Paganini</text></g>
+                <g class="node gov"><circle class="av-bg" cx="295" cy="80" r="30" fill="url(#pat-tyrell)"/><circle class="av-ring" cx="295" cy="80" r="30"/><text class="label" x="295" y="130"><tspan x="295">柯林·泰瑞尔</tspan><tspan class="label-en" x="295" dy="15">（Colin Tyrell）</tspan></text></g>
+                <g class="node gov"><circle class="av-bg" cx="120" cy="150" r="30" fill="url(#pat-irene)"/><circle class="av-ring" cx="120" cy="150" r="30"/><text class="label" x="120" y="200"><tspan x="120">艾琳</tspan><tspan class="label-en" x="120" dy="15">（Irene）</tspan></text></g>
+                <g class="node gov"><circle class="av-bg" cx="130" cy="290" r="30" fill="url(#pat-natasha)"/><circle class="av-ring" cx="130" cy="290" r="30"/><text class="label" x="130" y="340"><tspan x="130">娜塔莎</tspan><tspan class="label-en" x="130" dy="15">（Natasha）</tspan></text></g>
+                <g class="node gov"><circle class="av-bg" cx="130" cy="410" r="30" fill="url(#pat-paganini)"/><circle class="av-ring" cx="130" cy="410" r="30"/><text class="label" x="130" y="460"><tspan x="130">帕加尼尼</tspan><tspan class="label-en" x="130" dy="15">（Paganini）</tspan></text></g>
 
                 <!-- HERO -->
-                <g class="node hero"><circle class="av-bg" cx="580" cy="80" r="30" fill="url(#pat-flowen)"/><circle class="av-ring" cx="580" cy="80" r="30"/><text class="label" x="580" y="130">Flowen</text></g>
-                <g class="node hero"><circle class="av-bg" cx="460" cy="240" r="30" fill="url(#pat-rico)"/><circle class="av-ring" cx="460" cy="240" r="30"/><text class="label" x="460" y="290">Red Ring Rico</text></g>
-                <g class="node alt"><circle class="av-bg" cx="440" cy="530" r="30" fill="url(#pat-endu)"/><circle class="av-ring" cx="440" cy="530" r="30"/><text class="label" x="440" y="580">Endu</text></g>
+                <g class="node hero"><circle class="av-bg" cx="580" cy="80" r="30" fill="url(#pat-flowen)"/><circle class="av-ring" cx="580" cy="80" r="30"/><text class="label" x="580" y="130"><tspan x="580">弗洛文</tspan><tspan class="label-en" x="580" dy="15">（Flowen）</tspan></text></g>
+                <g class="node hero"><circle class="av-bg" cx="460" cy="240" r="30" fill="url(#pat-rico)"/><circle class="av-ring" cx="460" cy="240" r="30"/><text class="label" x="460" y="290"><tspan x="460">红环莉可</tspan><tspan class="label-en" x="460" dy="15">（Red Ring Rico）</tspan></text></g>
+                <g class="node alt"><circle class="av-bg" cx="440" cy="530" r="30" fill="url(#pat-endu)"/><circle class="av-ring" cx="440" cy="530" r="30"/><text class="label" x="440" y="580"><tspan x="440">恩杜</tspan><tspan class="label-en" x="440" dy="15">（Endu）</tspan></text></g>
 
                 <!-- BOSS -->
-                <g class="node boss"><circle class="av-bg" cx="310" cy="370" r="30" fill="url(#pat-darkfalz)"/><circle class="av-ring" cx="310" cy="370" r="30"/><text class="label" x="310" y="420">Dark Falz</text></g>
-                <g class="node boss"><circle class="av-bg" cx="580" cy="370" r="30" fill="url(#pat-olga)"/><circle class="av-ring" cx="580" cy="370" r="30"/><text class="label" x="580" y="420">Olga Flow</text></g>
-                <g class="node boss"><circle class="av-bg" cx="710" cy="885" r="30" fill="url(#pat-mother)"/><circle class="av-ring" cx="710" cy="885" r="30"/><text class="label" x="710" y="935">Mother Trinity</text></g>
+                <g class="node boss"><circle class="av-bg" cx="310" cy="370" r="30" fill="url(#pat-darkfalz)"/><circle class="av-ring" cx="310" cy="370" r="30"/><text class="label" x="310" y="420" style="font-size:11px"><tspan x="310">暗黑佛 / 黑暗法尔兹</tspan><tspan class="label-en" x="310" dy="15">（Dark Falz）</tspan></text></g>
+                <g class="node boss"><circle class="av-bg" cx="580" cy="370" r="30" fill="url(#pat-olga)"/><circle class="av-ring" cx="580" cy="370" r="30"/><text class="label" x="580" y="420"><tspan x="580">奥尔加·弗洛</tspan><tspan class="label-en" x="580" dy="15">（Olga Flow）</tspan></text></g>
+                <g class="node boss"><circle class="av-bg" cx="710" cy="885" r="30" fill="url(#pat-mother)"/><circle class="av-ring" cx="710" cy="885" r="30"/><text class="label" x="710" y="929"><tspan x="710">三位一体母神</tspan><tspan class="label-en" x="710" dy="15">（Mother Trinity）</tspan></text></g>
 
                 <!-- SCIENTISTS -->
-                <g class="node sci"><circle class="av-bg" cx="800" cy="80" r="30" fill="url(#gradSci)"/><circle class="av-ring" cx="800" cy="80" r="30"/><text class="initials" x="800" y="80">OH</text><text class="label" x="800" y="130">Dr. Osto</text></g>
-                <g class="node sci"><circle class="av-bg" cx="980" cy="80" r="30" fill="url(#pat-montague)"/><circle class="av-ring" cx="980" cy="80" r="30"/><text class="label" x="980" y="130">Dr. Montague</text></g>
-                <g class="node sci"><circle class="av-bg" cx="1265" cy="80" r="30" fill="url(#pat-elenor)"/><circle class="av-ring" cx="1265" cy="80" r="30"/><text class="label" x="1265" y="130">Elenor</text></g>
-                <g class="node sci"><circle class="av-bg" cx="1265" cy="220" r="30" fill="url(#pat-alicia)"/><circle class="av-ring" cx="1265" cy="220" r="30"/><text class="label" x="1265" y="270">Alicia Baz</text></g>
-                <g class="node alt"><circle class="av-bg" cx="1260" cy="370" r="30" fill="url(#pat-calus)"/><circle class="av-ring" cx="1260" cy="370" r="30"/><text class="label" x="1260" y="420">Calus</text></g>
+                <g class="node sci"><circle class="av-bg" cx="800" cy="80" r="30" fill="url(#gradSci)"/><circle class="av-ring" cx="800" cy="80" r="30"/><text class="initials" x="800" y="80">OH</text><text class="label" x="800" y="130"><tspan x="800">奥斯托博士</tspan><tspan class="label-en" x="800" dy="15">（Dr. Osto）</tspan></text></g>
+                <g class="node sci"><circle class="av-bg" cx="980" cy="80" r="30" fill="url(#pat-montague)"/><circle class="av-ring" cx="980" cy="80" r="30"/><text class="label" x="980" y="130"><tspan x="980">蒙塔古博士</tspan><tspan class="label-en" x="980" dy="15">（Dr. Montague）</tspan></text></g>
+                <g class="node sci"><circle class="av-bg" cx="1265" cy="80" r="30" fill="url(#pat-elenor)"/><circle class="av-ring" cx="1265" cy="80" r="30"/><text class="label" x="1265" y="130"><tspan x="1265">艾尔诺亚</tspan><tspan class="label-en" x="1265" dy="15">（Elenor）</tspan></text></g>
+                <g class="node sci"><circle class="av-bg" cx="1265" cy="220" r="30" fill="url(#pat-alicia)"/><circle class="av-ring" cx="1265" cy="220" r="30"/><text class="label" x="1265" y="270"><tspan x="1265">艾莉西亚·巴兹</tspan><tspan class="label-en" x="1265" dy="15">（Alicia Baz）</tspan></text></g>
+                <g class="node alt"><circle class="av-bg" cx="1260" cy="370" r="30" fill="url(#pat-calus)"/><circle class="av-ring" cx="1260" cy="370" r="30"/><text class="label" x="1260" y="420"><tspan x="1260">卡鲁斯</tspan><tspan class="label-en" x="1260" dy="15">（Calus）</tspan></text></g>
 
                 <!-- BLACK PAPER -->
-                <g class="node bp"><circle class="av-bg" cx="900" cy="390" r="30" fill="url(#pat-kireek)"/><circle class="av-ring" cx="900" cy="390" r="30"/><text class="label" x="900" y="440">Kireek</text></g>
-                <g class="node bp"><circle class="av-bg" cx="1080" cy="390" r="30" fill="url(#pat-sue)"/><circle class="av-ring" cx="1080" cy="390" r="30"/><text class="label" x="1080" y="440">Sue</text></g>
-                <g class="node bp"><circle class="av-bg" cx="930" cy="500" r="28" fill="url(#pat-tobokke)"/><circle class="av-ring" cx="930" cy="500" r="28"/><text class="label" x="930" y="546" style="font-size:12px">Tobokke / Tonzlar</text></g>
+                <g class="node bp"><circle class="av-bg" cx="900" cy="390" r="30" fill="url(#pat-kireek)"/><circle class="av-ring" cx="900" cy="390" r="30"/><text class="label" x="900" y="440"><tspan x="900">基里克</tspan><tspan class="label-en" x="900" dy="15">（Kireek）</tspan></text></g>
+                <g class="node bp"><circle class="av-bg" cx="1080" cy="390" r="30" fill="url(#pat-sue)"/><circle class="av-ring" cx="1080" cy="390" r="30"/><text class="label" x="1080" y="440"><tspan x="1080">苏</tspan><tspan class="label-en" x="1080" dy="15">（Sue）</tspan></text></g>
+                <g class="node bp"><circle class="av-bg" cx="930" cy="500" r="28" fill="url(#pat-tobokke)"/><circle class="av-ring" cx="930" cy="500" r="28"/><text class="label" x="930" y="546" style="font-size:12px"><tspan x="930">托波克 / 通兹拉</tspan><tspan class="label-en" x="930" dy="15">（Tobokke / Tonzlar）</tspan></text></g>
 
                 <!-- GUILD bottom row -->
-                <g class="node guild"><circle class="av-bg" cx="200" cy="700" r="30" fill="url(#pat-nol)"/><circle class="av-ring" cx="200" cy="700" r="30"/><text class="label" x="200" y="750">Nol Rinale</text></g>
-                <g class="node guild"><circle class="av-bg" cx="350" cy="700" r="30" fill="url(#pat-momoka)"/><circle class="av-ring" cx="350" cy="700" r="30"/><text class="label" x="350" y="750">Momoka</text></g>
-                <g class="node guild"><circle class="av-bg" cx="500" cy="700" r="30" fill="url(#pat-ash)"/><circle class="av-ring" cx="500" cy="700" r="30"/><text class="label" x="500" y="750">Ash</text></g>
-                <g class="node guild"><circle class="av-bg" cx="650" cy="730" r="30" fill="url(#pat-bernie)"/><circle class="av-ring" cx="650" cy="730" r="30"/><text class="label" x="650" y="780">Bernie</text></g>
-                <g class="node guild"><circle class="av-bg" cx="810" cy="730" r="30" fill="url(#pat-zoke)"/><circle class="av-ring" cx="810" cy="730" r="30"/><text class="label" x="810" y="780">Zoke Miyama</text></g>
-                <g class="node guild"><circle class="av-bg" cx="970" cy="730" r="30" fill="url(#pat-shino)"/><circle class="av-ring" cx="970" cy="730" r="30"/><text class="label" x="970" y="780">Shino</text></g>
-                <g class="node guild"><circle class="av-bg" cx="1130" cy="700" r="30" fill="url(#pat-rupika)"/><circle class="av-ring" cx="1130" cy="700" r="30"/><text class="label" x="1130" y="750">Rupika</text></g>
+                <g class="node guild"><circle class="av-bg" cx="200" cy="700" r="30" fill="url(#pat-nol)"/><circle class="av-ring" cx="200" cy="700" r="30"/><text class="label" x="200" y="750"><tspan x="200">诺尔·莉奈尔</tspan><tspan class="label-en" x="200" dy="15">（Nol Rinale）</tspan></text></g>
+                <g class="node guild"><circle class="av-bg" cx="350" cy="700" r="30" fill="url(#pat-momoka)"/><circle class="av-ring" cx="350" cy="700" r="30"/><text class="label" x="350" y="750"><tspan x="350">莫莫卡</tspan><tspan class="label-en" x="350" dy="15">（Momoka）</tspan></text></g>
+                <g class="node guild"><circle class="av-bg" cx="500" cy="700" r="30" fill="url(#pat-ash)"/><circle class="av-ring" cx="500" cy="700" r="30"/><text class="label" x="500" y="750"><tspan x="500">阿修</tspan><tspan class="label-en" x="500" dy="15">（Ash）</tspan></text></g>
+                <g class="node guild"><circle class="av-bg" cx="650" cy="730" r="30" fill="url(#pat-bernie)"/><circle class="av-ring" cx="650" cy="730" r="30"/><text class="label" x="650" y="780"><tspan x="650">伯尼</tspan><tspan class="label-en" x="650" dy="15">（Bernie）</tspan></text></g>
+                <g class="node guild"><circle class="av-bg" cx="810" cy="730" r="30" fill="url(#pat-zoke)"/><circle class="av-ring" cx="810" cy="730" r="30"/><text class="label" x="810" y="780"><tspan x="810">佐克·美山</tspan><tspan class="label-en" x="810" dy="15">（Zoke Miyama）</tspan></text></g>
+                <g class="node guild"><circle class="av-bg" cx="970" cy="730" r="30" fill="url(#pat-shino)"/><circle class="av-ring" cx="970" cy="730" r="30"/><text class="label" x="970" y="780"><tspan x="970">紫乃</tspan><tspan class="label-en" x="970" dy="15">（Shino）</tspan></text></g>
+                <g class="node guild"><circle class="av-bg" cx="1130" cy="700" r="30" fill="url(#pat-rupika)"/><circle class="av-ring" cx="1130" cy="700" r="30"/><text class="label" x="1130" y="750"><tspan x="1130">鲁毕卡</tspan><tspan class="label-en" x="1130" dy="15">（Rupika）</tspan></text></g>
 
                 <!-- 富舅舅 -->
                 <g class="node muted"><circle class="av-bg" cx="550" cy="840" r="24" fill="#334155"/><circle class="av-ring" cx="550" cy="840" r="24" style="stroke-width:1.5"/><text class="initials" x="550" y="840" style="font-size:13px">叔</text><text class="label" x="550" y="880" style="font-size:12px">富舅舅</text></g>

--- a/tests/e2e/site-smoke.spec.mjs
+++ b/tests/e2e/site-smoke.spec.mjs
@@ -70,6 +70,14 @@ const pages = [
     minimumReadyCount: 1,
   },
   {
+    name: 'NPC guide',
+    path: '/guide/npc.html',
+    title: /NPC 人物志/,
+    heading: 'NPC 人物志',
+    readySelector: '.npc-card',
+    minimumReadyCount: 25,
+  },
+  {
     name: '404 page',
     path: '/this-page-does-not-exist',
     title: /页面未找到/,
@@ -152,6 +160,33 @@ for (const pageCase of pages) {
     expect(runtimeErrors).toEqual([]);
   });
 }
+
+test('NPC guide keeps card and relationship names bilingual', async ({ page }) => {
+  await page.goto('/guide/npc.html');
+
+  const bilingualName = /[\u3400-\u9fff].*（[^）]*[A-Za-z][^）]*）/;
+  const cardNames = await page.locator('.npc-name').evaluateAll((elements) => (
+    elements.map((element) => element.firstChild?.textContent.trim() || '')
+  ));
+  expect(cardNames).toHaveLength(25);
+  for (const name of cardNames) expect(name).toMatch(bilingualName);
+  expect(cardNames).toContain('暗黑佛 / 黑暗法尔兹（Dark Falz）');
+
+  const graphNames = await page.locator('.rel-svg .node:not(.muted) > text.label')
+    .evaluateAll((elements) => elements.map((element) => ({
+      name: element.textContent.trim(),
+      lines: element.querySelectorAll('tspan').length,
+      english: element.querySelector('.label-en')?.textContent.trim() || '',
+    })));
+  expect(graphNames).toHaveLength(25);
+  for (const { name, lines, english } of graphNames) {
+    expect(name).toMatch(bilingualName);
+    expect(lines).toBe(2);
+    expect(english).toMatch(/^（.*[A-Za-z].*）$/);
+  }
+  expect(graphNames.map(({ name }) => name))
+    .toContain('暗黑佛 / 黑暗法尔兹（Dark Falz）');
+});
 
 for (const calculatorPath of ['/tools/cc.html', '/tools/ccopm.html']) {
   test(`${calculatorPath} exercises calculator controls and enemy groups`, async ({ page }) => {


### PR DESCRIPTION
## 变更内容

- 为 NPC 人物志的 25 张卡片补齐中文译名，并以括号保留英文原名
- 将关系图的 25 个姓名节点同步改为中英双行显示
- 将 Dark Falz 统一标记为“暗黑佛 / 黑暗法尔兹（Dark Falz）”
- 增加 NPC 页面资源加载和双语姓名端到端回归测试

## 原因

NPC 页面此前有多个人物只显示英文名，卡片与关系图的姓名格式也不一致。

## 用户影响

中文读者可以直接识别人物译名，同时仍能依据英文原名查阅英文资料；桌面端和移动端布局保持正常。

## 验证

- `npm run build`
- `npm test`
- `npm run test:e2e`（21 项全部通过）
- `git diff --check`
- 桌面端与 390px 移动端视觉检查，无标签重叠或页面横向溢出
